### PR TITLE
Correctly set the secure protocol

### DIFF
--- a/lib/plex_socket.js
+++ b/lib/plex_socket.js
@@ -43,7 +43,7 @@ class PlexSocket extends EventEmitter {
     }
 
     buildAddress() {
-        const protocol = this.https ? 'wss' : 'ws';
+        const protocol = this.secure ? 'wss' : 'ws';
         return `${protocol}://${this.hostname}:${this.port}/:/websockets/notifications`;
     }
 


### PR DESCRIPTION
Previously we were checking an `https` property, which doesn't appear to exist.

If the Plex server had set Secure Connections to **Required**, the node would always error out with `error socket hang up`, regardless of the **Enable secure (SSL/TLS) connection** setting.