### PR TITLE
Destroy fetchAllPromise on error

### DIFF
--- a/lib/session_store.js
+++ b/lib/session_store.js
@@ -58,7 +58,12 @@ class SessionStore {
             } else {
                 this.fetchAll()
                     .then(cache => resolve(cache[sessionKey]))
-                    .catch(reject);
+                    .catch(
+						(err) => {
+							this.fetchAllPromise = null;
+							reject(err);
+						}
+					);
             }
         });
     }


### PR DESCRIPTION
The fetchAllPromise should be destroyed on error, ex. to many retries. This can happen when the user stops the session before it is fetched. See issue #3.